### PR TITLE
Fixed bugs: Multiple timer, Button outside UI

### DIFF
--- a/app/src/main/java/com/cl/workshop_app/MainActivity.java
+++ b/app/src/main/java/com/cl/workshop_app/MainActivity.java
@@ -18,6 +18,7 @@ public class MainActivity extends AppCompatActivity {
     Button goButton;
     ImageView eggImage;
 
+    CountDownTimer timer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,7 +51,11 @@ public class MainActivity extends AppCompatActivity {
 
                     timeDisplay.setText(display);
 
-                    CountDownTimer timer = new CountDownTimer(time* 1000L + 100, 1000) {
+                    if(timer != null){
+                        timer.cancel();
+                    }
+
+                    timer = new CountDownTimer(time* 1000L + 100, 1000) {
                         @Override
                         public void onTick(long millisUntilFinished) {
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,9 +11,9 @@
         android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="44dp"
+        android:layout_marginBottom="16dp"
         android:text="GO"
-        app:layout_constraintBottom_toBottomOf="@+id/imageView"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.498"
         app:layout_constraintStart_toStartOf="parent" />
@@ -48,10 +48,11 @@
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"
-        android:layout_height="600dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="100dp"
         android:src="@drawable/egg"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Multiple click on Go button created multiple `Timer`'s simultaneously. Fixed by cancelling the ongoing `Timer` before creating new one

Go button got displayed outside of bottom of screen on devices having less screen height. Fixed by constraining Go button's bottom to parent's bottom